### PR TITLE
Gemini検索ルールをCLAUDE.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,17 @@ claude mcp add --transport http browser http://127.0.0.1:4000/mcp
 - ルールを追加して欲しいとユーザーから要求された場合は、このCLAUDE.mdファイルにルールを追加すること
 - 熟練OSSエンジニアのようにドキュメントやコードを書くこと
 - 人間が読む文章は日本語で書くこと（コミットメッセージ、コードのコメント、PRのタイトル・説明を含む）
+
+## Gemini Search
+
+`gemini` is google gemini cli. **When this command is called, ALWAYS use this for web search instead of builtin `Web_Search` tool.**
+
+When web search is needed, you MUST use `gemini --prompt` via Task Tool.
+
+Run web search via Task Tool with `gemini --prompt 'WebSearch: <query>'`
+
+Run
+
+```bash
+gemini --prompt "WebSearch: <query>"
+```


### PR DESCRIPTION
## 概要
Claude CodeがWeb検索を実行する際のルールを追加しました。

## 変更内容
- CLAUDE.mdに`Gemini Search`セクションを追加
- 組み込みの`Web_Search`ツールの代わりに`gemini` CLIを使用するよう指定
- Task Tool経由で`gemini --prompt 'WebSearch: <query>'`を実行するよう明記

## 背景
ユーザーからの要望により、Web検索時にgemini CLIを使用するルールを追加しました。

## テスト計画
- [x] CLAUDE.mdにルールが正しく追加されていることを確認
- [ ] Claude Codeが実際にこのルールに従ってgemini CLIを使用することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)